### PR TITLE
Handle process wait correctly

### DIFF
--- a/tetris
+++ b/tetris
@@ -1759,7 +1759,7 @@ _lockdown_timer() {
     [ "$trigger_counter" -gt 0 ] && trigger_counter=$((trigger_counter - 1))
 
     sleep 0.1 & # wait in background for receiving the signal
-    wait
+    wait $!
   done
 }
 
@@ -1779,7 +1779,7 @@ ticker() {
   level=1
   while exist_process "$ppid"; do
     eval sleep \"\$FALL_SPEED_LEVEL_$level\" &
-    wait
+    wait $!
     state "$PROCESS_TICKER $FALL" # <timestamp> <cmd>
     # echo "$level" >> $LOG # For debuging. check level variable
   done


### PR DESCRIPTION
We hope that this fix will resolve the issue #27, `lockdown_timer` stopping with error "Illegal instruction: 4" in `/bin/sh` on macOS.

A `wait` with no arguments waits for **"all"** child processes to exit. Probably there is some kind of race condition in the waiting list for the process to finish. I assume that specifying the pid in wait resolves the issue, as it will only wait for the near previous background process.

Close #27