### PR TITLE
Fix program name in zsh

### DIFF
--- a/tetris
+++ b/tetris
@@ -52,6 +52,8 @@ set -u # non initialized variable is an error
 # so that users have a clear indicator of when an upgrade will introduce breaking changes.
 VERSION='2.2.0-alpha'
 
+PROG=${0##*/}
+
 # the year the game was created.
 # displayed in COPYRIGHT.
 CREATED_YEAR='2021'
@@ -395,7 +397,7 @@ Q, ESCx2  Quit
 '
 
 USAGE="
-Usage: ${0##*/} [options]
+Usage: $PROG [options]
 
 Options:
  -d, --debug          debug mode
@@ -1936,7 +1938,7 @@ game_cleanup() {
 # Arguments:
 #   Error message
 die_usage() {
-  echo "${0##*/}: $1" 1>&2
+  echo "$PROG: $1" 1>&2
   echo "$USAGE" 1>&2; exit 1
 }
 


### PR DESCRIPTION
In zsh, `$0` becomes the function name in the function.

```console
$ sh tetris -a
tetris: unrecognized option '-a'

$ zsh tetris -a
die_usage: unrecognized option '-a'
```