### PR TITLE
test_hard_drop without command substitution

### DIFF
--- a/tetris
+++ b/tetris
@@ -1326,20 +1326,19 @@ soft_drop() {
   }
 }
 
-test_hard_drop() {
-  # no need local attribute.
-  # this function will called as "Command Substitution" `$()`
-  x=$1; y=$(( $2 - 1 ))
+localvar test_hard_drop x y
+_test_hard_drop() {
+  x=$2; y=$(( $3 - 1 ))
   while new_piece_location_ok $x $y; do
     y=$(( y - 1 ))
   done
-  echo $(( y + 1 ))
+  eval "$1=\$(( y + 1 ))"
 }
 
 localvar hard_drop new_y
 _hard_drop() {
   # move piece all way down
-  new_y=$(test_hard_drop $current_piece_x $current_piece_y)
+  test_hard_drop new_y $current_piece_x $current_piece_y
 
   update_score "$ACTION_HARD_DROP" $(( current_piece_y - new_y ))
   move_piece $current_piece_x $new_y
@@ -1359,7 +1358,7 @@ update_ghost() {
 # Update ghost piece with new location according to current piece.
 localvar show_ghost new_y color
 _show_ghost() {
-  new_y=$(test_hard_drop $current_piece_x $current_piece_y)
+  test_hard_drop new_y $current_piece_x $current_piece_y
 
   ghost_piece=$current_piece
   ghost_piece_x=$current_piece_x; ghost_piece_y=$new_y


### PR DESCRIPTION
Command Substitution is slow. **1ms** is a long time in a real time game.

```sh
$ time sh -c 'i=0; while [ $i -lt 1000 ]; do i=$((i+1)); v=$(echo 1); done'
real	0m1.096s
user	0m0.335s
sys	0m0.637s

$ time sh -c 'i=0; while [ $i -lt 1000 ]; do i=$((i+1)); done'
real	0m0.024s
user	0m0.018s
sys	0m0.006s

$ time sh -c 'i=0; while [ $i -lt 1000 ]; do i=$((i+1)); v=1; done'
real	0m0.029s
user	0m0.023s
sys	0m0.005s

$ time sh -c 'i=0; while [ $i -lt 1000 ]; do i=$((i+1)); eval "v=1"; done'
real	0m0.041s
user	0m0.034s
sys	0m0.006s
```