### PR TITLE
Remove timestamp

### DIFF
--- a/tetris
+++ b/tetris
@@ -108,6 +108,7 @@ SIGNAL_LEVEL_UP=USR1
 SIGNAL_RESET_LEVEL=USR2
 SIGNAL_CANCEL_LOCKDOWN_TIMER=USR1
 SIGNAL_RESTART_LOCKDOWN_TIMER=USR2
+SIGNAL_UNPAUSE=USR1
 
 # Those are commands sent to controller by key press processing code
 # In controller they are used as index to retrieve actual function from array
@@ -1778,6 +1779,7 @@ _init() {
   done
 
   send_signal "$SIGNAL_CONT" "$ticker_pid" "$timer_pid"
+  send_signal "$SIGNAL_UNPAUSE" "$reader_pid"
 
   get_next
   redraw_screen
@@ -1848,8 +1850,9 @@ localvar reader key a b cmd
 _reader() {
   # this process exits on SIGTERM
   trap exit $SIGNAL_TERM
+  trap 'paused=false' $SIGNAL_UNPAUSE
 
-  a='' b=''
+  a='' b='' paused=true
 
   game_pid=$1
   get_pid my_pid
@@ -1861,11 +1864,11 @@ _reader() {
   while exist_process "$game_pid"; do
     # read one key
     key=$(dd ibs=1 count=1 2>/dev/null)
-    cmd=''
-
     # echo "$key" >> $LOG # For debug to check input char.
     # printf '%s' "$key" | od -An -tx1 >> $LOG # For debug to check input char as hex value.
 
+    "$paused" && continue
+    cmd=''
     case "$a$b$key" in
       # 2 escapes
       *"$ESC_CH""$ESC_CH")

--- a/tetris
+++ b/tetris
@@ -103,6 +103,7 @@ LOG='.log'
 SIGNAL_TERM=TERM
 SIGNAL_INT=INT
 SIGNAL_LEVEL_UP=USR1
+SIGNAL_RESET_LEVEL=USR2
 SIGNAL_CANCEL_LOCKDOWN_TIMER=USR1
 SIGNAL_RESTART_LOCKDOWN_TIMER=USR2
 
@@ -122,8 +123,7 @@ TOGGLE_COLOR=10
 TOGGLE_HELP=11
 REFRESH_SCREEN=12
 LOCKDOWN=13
-ACK=14
-MY_PID=15
+MY_PID=14
 
 PROCESS_CONTROLLER=0
 PROCESS_TICKER=1
@@ -467,7 +467,7 @@ bag_random=0
 # To speed up the process of “clearing” 600 lines, in the Variable Goal System the number of Line
 # Clears awarded for any action is directly based off the score of the action performed (score
 # at level 1 / 100 = Total Line Clears
-goal=5
+adding_lines_per_level=5
 
 # There is a special bonus for Back-to-Backs, which is when two actions
 # such as a Tetris and T-Spin Double take place without a Single, Double, or Triple Line Clear
@@ -481,7 +481,8 @@ b2b_sequence_continues=false
 lockdown_rule=$LOCKDOWN_RULE_EXTENDED
 
 score=0                    # score variable initialization
-level=1                    # level variable initialization
+level=0                    # level variable initialization
+goal=0                     # goal variable initialization
 lines_completed=0          # completed lines counter initialization
 actions_to_show=''         #
 already_hold=false         #
@@ -718,10 +719,24 @@ _shuffle() {
   eval "$varname=\${shuffled}\${1}" # set result
 }
 
+reset_level() {
+  level=0 goal=0 lines_completed=0
+  while [ "$level" -lt "$starting_level" ]; do
+    increment_level
+  done
+  # send reset level signal to ticker (please see ticker for more details)
+  send_signal "$SIGNAL_RESET_LEVEL" "$ticker_pid"
+}
+
 level_up() {
-  level=$((level + 1))                     # increment level
-  goal=$((goal + level * 5))               # adding an additional five lines to the Goal
-  send_signal $SIGNAL_LEVEL_UP $ticker_pid # and send level-up signal to all instances of this script (please see ticker for more details)
+  increment_level
+  # send level-up signal to ticker (please see ticker for more details)
+  send_signal "$SIGNAL_LEVEL_UP" "$ticker_pid"
+}
+
+increment_level() {
+  level=$((level + 1))                            # increment level
+  goal=$((goal + level * adding_lines_per_level)) # adding an additional lines to the Goal
 }
 
 fill_bag() {
@@ -1753,27 +1768,8 @@ _init() {
     }
   done
 
-  $debug && echo "Leveling up to $starting_level" >> $LOG
-  $debug && printf "> $level " >> $LOG
-  # level up until reach starting level
-  while [ $level -lt $starting_level ]; do
-    level_up
-    $debug && printf "$level " >> $LOG
-
-    # Wait until ticker ACKnowledgement response
-    while read statement; do
-      set -- $statement
-      [ $# -eq 3 ]               &&
-      [ $2 -eq $PROCESS_TICKER ] &&
-      [ $3 -eq $ACK ]            && {
-        break
-      }
-    done
-
-    printf '\r'; print_loading_spin; printf ' %s' "$level/$starting_level"
-    sleep 0.1
-  done
-  $debug && echo ' ...OK' >> $LOG
+  # reset to starting level
+  reset_level
 
   # now setup play screen
   clear
@@ -1829,19 +1825,20 @@ _lockdown_timer() {
 }
 
 # this function runs in separate process
-# it sends DOWN commands to controller with appropriate delay
+# it sends FALL commands to controller with appropriate delay
 ticker() {
   # on SIGTERM this process should exit
   trap exit $SIGNAL_TERM
   # on this signal fall speed should be increased, this happens during level ups
-  trap 'level=$((level + 1)); state "$PROCESS_TICKER $ACK"' $SIGNAL_LEVEL_UP
+  trap 'level=$((level + 1))' $SIGNAL_LEVEL_UP
+  trap 'level=$starting_level' $SIGNAL_RESET_LEVEL
 
   game_pid=$1
   get_pid my_pid
   state "$PROCESS_TICKER $MY_PID $my_pid"
 
   # the game level, which levelup-signal counts up.
-  level=1
+  level=$starting_level
   while exist_process "$game_pid"; do
     eval sleep \"\$FALL_SPEED_LEVEL_$level\"
 
@@ -1967,7 +1964,7 @@ _controller() {
       [ "$issued_time" -gt "$discard_cmds_timepoint" ] && break
     done
     case $cmd in
-      "$ACK"|"$MY_PID")              ;; # ignore
+      "$MY_PID")              ;; # ignore
       *)
         eval eval \"\$commands_"$cmd"\" # run command
         flush_screen

--- a/tetris
+++ b/tetris
@@ -102,6 +102,8 @@ LOG='.log'
 #   in shell enviroment, should Drop the SIG prefix, just input the signal name.
 SIGNAL_TERM=TERM
 SIGNAL_INT=INT
+SIGNAL_STOP=STOP
+SIGNAL_CONT=CONT
 SIGNAL_LEVEL_UP=USR1
 SIGNAL_RESET_LEVEL=USR2
 SIGNAL_CANCEL_LOCKDOWN_TIMER=USR1
@@ -490,7 +492,6 @@ help_on=true               # if this flag is true help is shown, if false, hide
 beep_on=true               #
 no_color=false             # do we use color or not
 running=true               # controller runs while this flag is true
-discard_cmds_timepoint=0   # cmds issued before this time is discarded
 empty_cell=' .'            # how we draw empty cell
 filled_cell='[]'           # how we draw filled cell
 ghost_cell='░░'            # how we draw ghost cell
@@ -602,12 +603,8 @@ beep() {
   printf '\007'
 }
 
-now() {
-  date +"${1:-%s}"
-}
-
 state() {
-  now "%s $1"
+  echo "$1"
 }
 
 current_loading_spin_shift=0
@@ -638,15 +635,11 @@ get_pid(){
 }
 
 send_signal() {
-  kill -$1 $2
+  kill "-$@"
 }
 
 exist_process() {
   send_signal 0 "$1" 2>/dev/null
-}
-
-discard_cmds() {
-  discard_cmds_timepoint=$(now)
 }
 
 # return random value (0 ~ 4294967295)
@@ -1030,7 +1023,6 @@ process_fallen_piece() {
 
   beep
   redraw_playfield
-  discard_cmds
 }
 
 draw_scoreboard() {
@@ -1698,7 +1690,7 @@ quit() {
   flush_screen
 }
 
-localvar init x y i from cmd pid statement
+localvar init x y i from cmd pid
 _init() {
   clear
   $debug || echo "$COPYRIGHT"
@@ -1743,29 +1735,24 @@ _init() {
   done
 
   $debug && echo 'Checking subprocess pid' >> $LOG
-  ticker_pid=''; timer_pid=''; reader_pid=''
+  ticker_pid='' timer_pid='' reader_pid=''
   while [ -z $ticker_pid ] || [ -z $timer_pid ] || [ -z $reader_pid ]; do
-    read statement
-    set -- $statement
-    [ $# -lt 4 ] && continue
-    from=$2; cmd=$3; pid=$4
-
-    [ $cmd -eq $MY_PID ] && {
-      case $from in
-        $PROCESS_TICKER)
-          ticker_pid=$4
-          $debug &&  echo "> ticker $ticker_pid ...OK" >> $LOG
-          ;;
-        $PROCESS_READER)
-          reader_pid=$4
-          $debug &&  echo "> reader $reader_pid ...OK" >> $LOG
-          ;;
-        $PROCESS_TIMER)
-          timer_pid=$4
-          $debug &&  echo "> timer  $timer_pid ...OK" >> $LOG
-          ;;
-      esac
-    }
+    read from cmd pid
+    [ "$cmd" = "$MY_PID" ] || continue
+    case $from in
+      $PROCESS_TICKER)
+        ticker_pid=$pid
+        $debug && echo "> ticker $ticker_pid ...OK" >> $LOG
+        ;;
+      $PROCESS_READER)
+        reader_pid=$pid
+        $debug && echo "> reader $reader_pid ...OK" >> $LOG
+        ;;
+      $PROCESS_TIMER)
+        timer_pid=$pid
+        $debug && echo "> timer  $timer_pid ...OK" >> $LOG
+        ;;
+    esac
   done
 
   # reset to starting level
@@ -1790,6 +1777,8 @@ _init() {
     i=$((i - 1))
   done
 
+  send_signal "$SIGNAL_CONT" "$ticker_pid" "$timer_pid"
+
   get_next
   redraw_screen
   flush_screen
@@ -1806,6 +1795,7 @@ _lockdown_timer() {
   game_pid=$1
   get_pid my_pid
   state "$PROCESS_TIMER $MY_PID $my_pid"
+  send_signal "$SIGNAL_STOP" "$my_pid"
 
   trigger_counter=-1  # -1 - already triggerd; 0 - triggered; greater than 0 - count to trigger
   while exist_process "$game_pid"; do
@@ -1836,6 +1826,7 @@ ticker() {
   game_pid=$1
   get_pid my_pid
   state "$PROCESS_TICKER $MY_PID $my_pid"
+  send_signal "$SIGNAL_STOP" "$my_pid"
 
   # the game level, which levelup-signal counts up.
   level=$starting_level
@@ -1846,7 +1837,7 @@ ticker() {
     #   eval sleep \"\$FALL_SPEED_LEVEL_$level\" &
     #   wait $!
 
-    state "$PROCESS_TICKER $FALL" # <timestamp> <cmd>
+    state "$PROCESS_TICKER $FALL"
 
     # echo "$level" >> $LOG # For debuging. check level variable
   done
@@ -1930,7 +1921,7 @@ _reader() {
   done
 }
 
-localvar controller cmd statement issued_time from
+localvar controller from cmd 
 _controller() {
   # These signals are ignored
   trap '' $SIGNAL_TERM
@@ -1952,24 +1943,11 @@ _controller() {
   eval commands_"$LOCKDOWN"=lockdown
 
   init
-  discard_cmds
 
-  while $running; do # run while this variable is true, it is changed to false in quit function
-    # read next command from stdout
-    # skip cmds issued before discard_cmds_timepoint
-    while read statement; do
-      set -- $statement
-      [ $# -lt 3 ] && continue   # validate param counts is 3 or more
-      issued_time="$1"; from="$2" cmd="$3"
-      [ "$issued_time" -gt "$discard_cmds_timepoint" ] && break
-    done
-    case $cmd in
-      "$MY_PID")              ;; # ignore
-      *)
-        eval eval \"\$commands_"$cmd"\" # run command
-        flush_screen
-        ;;
-    esac
+  while $running; do           # run while this variable is true, it is changed to false in quit function
+    read from cmd              # read next command from stdout
+    eval "\"\$commands_$cmd\"" # run command
+    flush_screen
   done
 }
 


### PR DESCRIPTION
Remove timestamp and `discard_cmds`.

Execution of external commands is slow. The `date` command takes about 3 ms to execute. The timestamp seems to be used to discard commands before the game starts. Instead, I used SIGSTOP and SIGCONT to implement stopping and restarting the timers. This also aims to implement a pause feature for the game in the future.

```sh
$ time sh -c 'i=0; while [ $i -lt 1000 ]; do i=$((i+1)); date +%s > /dev/null; done'

real	0m2.975s
user	0m0.827s
sys	0m1.532s
```

**This PR contains the commit of PR#37.**
