### PR TITLE
Fix displayed goal number when archiving lv 15

### DIFF
--- a/tetris
+++ b/tetris
@@ -756,6 +756,7 @@ level_up() {
 increment_level() {
   level=$((level + 1))                            # increment level
   goal=$((goal + level * adding_lines_per_level)) # adding an additional lines to the Goal
+  goal=$((goal % 600))                            # up to level 15
 }
 
 fill_bag() {


### PR DESCRIPTION
I make displayed number of goal lines into zero in level 15.
Ref: #44 

![image](https://user-images.githubusercontent.com/42153744/147397605-b18f8346-bc06-447f-9424-9cef3cd931c5.png)
