### PR TITLE
Remove extra input after game over

### DIFF
--- a/tetris
+++ b/tetris
@@ -1850,7 +1850,7 @@ toggle_color() {
 quit() {
   running=false # let's stop controller ...
   xyprint $GAMEOVER_X $GAMEOVER_Y 'Game Over!'
-  xyprint "$TERM_X" "$TERM_Y" '> Press any key to continue ...'
+  xyprint "$TERM_X" "$TERM_Y" '> Press enter to continue ...'
   flush_screen
   terminate_process "$timer_pid" "$ticker_pid" "$reader_pid"
 }
@@ -2052,6 +2052,7 @@ reader() {
       esac
     done
   }
+  read key # Remove extra input after game over.
 }
 
 controller() {


### PR DESCRIPTION
The `[D` frustrates me when I press the arrow keys after game over.

<img width="500" src="https://user-images.githubusercontent.com/2453619/148232266-cc86ae3e-8263-40bb-af23-3b9b09b95f6e.png">
