### PR TITLE
Refactoring draw_piece function

### DIFF
--- a/tetris
+++ b/tetris
@@ -1761,7 +1761,7 @@ redraw_playfield() {
 #   4 - rotation
 #   5 - cell content
 draw_piece() {
-  local posx="$1" posy="$2" type="$3" rotation="$4" content="$5" x=0 y=0
+  local posx="$1" posy="$2" type="$3" rotation="$4" content="$5"
 
   # set minos coordinates.
   eval set -- \$piece_"$type"_minos_"$rotation"
@@ -1769,11 +1769,8 @@ draw_piece() {
   # loop through tetrimino minos: 4 minos, each has 2 coordinates
   while [ $# -gt 0 ]; do
     # relative coordinates are retrieved based on orientation and added to absolute coordinates
-    x=$((posx + $1 * 2)) # the width of cell is 2 characters thick
-    y=$((posy + $2))
-
-    xyprint $x $y "$content"
-
+    # the width of cell is 2 characters thick
+    xyprint $((posx + $1 * 2)) $((posy + $2)) "$content"
     shift 2
   done
 }
@@ -1787,23 +1784,22 @@ draw_piece() {
 draw_playfield_piece() {
   local posx="$1" posy="$2" type="$3" rotation="$4" content="$5" x=0 y=0
 
-  # factor 2 for x because each cell is 2 characters wide
-  posx=$((PLAYFIELD_X + posx * 2))
-  posy=$((PLAYFIELD_Y + PLAYFIELD_H - 1 - posy))
-
   # set minos coordinates.
   eval set -- \$piece_"$type"_minos_"$rotation"
 
   # loop through tetrimino minos: 4 minos, each has 2 coordinates
   while [ $# -gt 0 ]; do
     # relative coordinates are retrieved based on orientation and added to absolute coordinates
-    x=$((posx + $1 * 2)) # the width of cell is 2 characters thick
-    y=$((posy + $2))
+    x=$((posx + $1)) 
+    y=$((PLAYFIELD_H - 1 - posy + $2))
 
-    [ "$y" -ge "$PLAYFIELD_Y" ]                     &&
-    [ "$y" -lt $((PLAYFIELD_Y + PLAYFIELD_H)) ]     &&
-    [ "$x" -ge "$PLAYFIELD_X" ]                     &&
-    [ "$x" -lt $((PLAYFIELD_X + PLAYFIELD_W * 2)) ] && xyprint $x $y "$content" # draw mino within playfield
+    [ "$y" -ge 0 ]              &&
+    [ "$y" -lt "$PLAYFIELD_H" ] &&
+    [ "$x" -ge 0 ]              &&
+    [ "$x" -lt "$PLAYFIELD_W" ] && {
+      # the width of cell is 2 characters thick
+      xyprint $((PLAYFIELD_X + x * 2)) $((PLAYFIELD_Y + y)) "$content"
+    }
 
     shift 2
   done

--- a/tetris
+++ b/tetris
@@ -1184,8 +1184,7 @@ process_fallen_piece() {
   }
 
   # flash piece effect
-  set_color "$FLASH_COLOR"
-  draw_current "$dry_cell"
+  flash_current
   flush_screen
   sleep 0.03
 
@@ -1810,20 +1809,20 @@ draw_playfield_piece() {
   done
 }
 
-# Arguments:
-#   1 - string to draw single cell
-draw_current() {
-  draw_playfield_piece $current_piece_x $current_piece_y $current_piece $current_piece_rotation "$1"
-}
-
 show_current() {
   set_piece_color "$current_piece"
-  draw_current "$filled_cell"
+  draw_playfield_piece $current_piece_x $current_piece_y $current_piece $current_piece_rotation "$filled_cell"
+  reset_colors
+}
+
+flash_current() {
+  set_color "$FLASH_COLOR"
+  draw_playfield_piece $current_piece_x $current_piece_y $current_piece $current_piece_rotation "$dry_cell"
   reset_colors
 }
 
 clear_current() {
-  draw_current "$empty_cell"
+  draw_playfield_piece $current_piece_x $current_piece_y $current_piece $current_piece_rotation "$empty_cell"
 }
 
 # Arguments:

--- a/tetris
+++ b/tetris
@@ -1761,33 +1761,53 @@ redraw_playfield() {
 #   3 - type
 #   4 - rotation
 #   5 - cell content
-#   6 - mask with playfield
 draw_piece() {
-  local posx="$1" posy="$2" type="$3" rotation="$4" content="$5" mask="${6:-false}" x=0 y=0
+  local posx="$1" posy="$2" type="$3" rotation="$4" content="$5" x=0 y=0
 
   # set minos coordinates.
   eval set -- \$piece_"$type"_minos_"$rotation"
 
   # loop through tetrimino minos: 4 minos, each has 2 coordinates
   while [ $# -gt 0 ]; do
-    # relative coordinates are retrieved bassed on orientation and added to absolute coordinates
+    # relative coordinates are retrieved based on orientation and added to absolute coordinates
     x=$((posx + $1 * 2)) # the width of cell is 2 characters thick
     y=$((posy + $2))
 
-    "$mask"                                         &&
-    [ "$y" -ge "$PLAYFIELD_Y" ]                     &&
-    [ "$y" -lt $((PLAYFIELD_Y + PLAYFIELD_H)) ]     &&
-    [ "$x" -ge "$PLAYFIELD_X" ]                     &&
-    [ "$x" -lt $((PLAYFIELD_X + PLAYFIELD_W * 2)) ] && xyprint $x $y "$content" # draw mino within playfield
-    "$mask"                                         || xyprint $x $y "$content"
+    xyprint $x $y "$content"
 
     shift 2
   done
 }
 
+# Arguments:
+#   1 - x
+#   2 - y
+#   3 - type
+#   4 - rotation
+#   5 - cell content
 draw_playfield_piece() {
+  local posx="$1" posy="$2" type="$3" rotation="$4" content="$5" x=0 y=0
+
   # factor 2 for x because each cell is 2 characters wide
-  draw_piece $((PLAYFIELD_X + $1 * 2)) $((PLAYFIELD_Y + PLAYFIELD_H - 1 - $2)) "$3" "$4" "$5" true
+  posx=$((PLAYFIELD_X + posx * 2))
+  posy=$((PLAYFIELD_Y + PLAYFIELD_H - 1 - posy))
+
+  # set minos coordinates.
+  eval set -- \$piece_"$type"_minos_"$rotation"
+
+  # loop through tetrimino minos: 4 minos, each has 2 coordinates
+  while [ $# -gt 0 ]; do
+    # relative coordinates are retrieved based on orientation and added to absolute coordinates
+    x=$((posx + $1 * 2)) # the width of cell is 2 characters thick
+    y=$((posy + $2))
+
+    [ "$y" -ge "$PLAYFIELD_Y" ]                     &&
+    [ "$y" -lt $((PLAYFIELD_Y + PLAYFIELD_H)) ]     &&
+    [ "$x" -ge "$PLAYFIELD_X" ]                     &&
+    [ "$x" -lt $((PLAYFIELD_X + PLAYFIELD_W * 2)) ] && xyprint $x $y "$content" # draw mino within playfield
+
+    shift 2
+  done
 }
 
 # Arguments:

--- a/tetris
+++ b/tetris
@@ -1686,45 +1686,6 @@ hold() {
   hold_tetrimino
 }
 
-update_ghost() {
-  local new_ghost_piece_y=0
-
-  test_hard_drop $current_piece_x $current_piece_y
-  new_ghost_piece_y=$((current_piece_y - $?))
-
-  [ "$ghost_piece_x" -eq "$current_piece_x" ]               &&
-  [ "$ghost_piece_y" -eq "$new_ghost_piece_y" ]             &&
-  [ "$ghost_piece" -eq "$current_piece" ]                   &&
-  [ "$ghost_piece_rotation" -eq "$current_piece_rotation" ] && return
-
-  clear_ghost
-  show_ghost "$new_ghost_piece_y"
-}
-
-# Update ghost piece with new location according to current piece.
-show_ghost() {
-  if [ $# -gt 0 ]; then
-    ghost_piece_y=$1
-  else
-    test_hard_drop $current_piece_x $current_piece_y
-    ghost_piece_y=$((current_piece_y - $?))
-  fi
-  ghost_piece=$current_piece
-  ghost_piece_x=$current_piece_x
-  ghost_piece_rotation=$current_piece_rotation
-
-  set_ghost_color "$current_piece"
-  draw_playfield_piece $ghost_piece_x $ghost_piece_y $ghost_piece $ghost_piece_rotation "$ghost_cell"
-
-  reset_colors
-}
-
-clear_ghost() {
-  ${ghost_piece+:} return
-
-  draw_playfield_piece $ghost_piece_x $ghost_piece_y  $ghost_piece $ghost_piece_rotation "$empty_cell"
-}
-
 # playfield is 2-dimensional array, data is stored as follows:
 # a_{y,x}
 #   x - 0, ..., (PLAYFIELD_W-1)
@@ -1819,6 +1780,45 @@ flash_current() {
 
 clear_current() {
   draw_playfield_piece $current_piece_x $current_piece_y $current_piece $current_piece_rotation "$empty_cell"
+}
+
+# Update ghost piece with new location according to current piece.
+show_ghost() {
+  if [ $# -gt 0 ]; then
+    ghost_piece_y=$1
+  else
+    test_hard_drop $current_piece_x $current_piece_y
+    ghost_piece_y=$((current_piece_y - $?))
+  fi
+  ghost_piece=$current_piece
+  ghost_piece_x=$current_piece_x
+  ghost_piece_rotation=$current_piece_rotation
+
+  set_ghost_color "$current_piece"
+  draw_playfield_piece $ghost_piece_x $ghost_piece_y $ghost_piece $ghost_piece_rotation "$ghost_cell"
+
+  reset_colors
+}
+
+clear_ghost() {
+  ${ghost_piece+:} return
+
+  draw_playfield_piece $ghost_piece_x $ghost_piece_y $ghost_piece $ghost_piece_rotation "$empty_cell"
+}
+
+update_ghost() {
+  local new_ghost_piece_y=0
+
+  test_hard_drop $current_piece_x $current_piece_y
+  new_ghost_piece_y=$((current_piece_y - $?))
+
+  [ "$ghost_piece_x" -eq "$current_piece_x" ]               &&
+  [ "$ghost_piece_y" -eq "$new_ghost_piece_y" ]             &&
+  [ "$ghost_piece" -eq "$current_piece" ]                   &&
+  [ "$ghost_piece_rotation" -eq "$current_piece_rotation" ] && return
+
+  clear_ghost
+  show_ghost "$new_ghost_piece_y"
 }
 
 # Arguments:


### PR DESCRIPTION
In my opinion, the current `draw_piece` does two essentially different things inside the playfield and outside the playfield, which makes the code more complex. I have split it into two functions to simplify the code.

`show_ghost`, `clear_ghost` and `update_ghost` just moved the definition location.