### PR TITLE
Fix lockdown timer

### DIFF
--- a/tetris
+++ b/tetris
@@ -2234,6 +2234,7 @@ ready() {
 # this function runs in separate process
 lockdown_timer() {
   game_pid=$1
+  trigger_counter=-1 # -1: already triggerd, 0: triggered, >0: count to trigger
 
   # on SIGTERM this process should exit
   trap exit $SIGNAL_TERM
@@ -2244,8 +2245,9 @@ lockdown_timer() {
   send_cmd "$NOTIFY_PID $PROCESS_TIMER $my_pid"
   stop_at_start "$my_pid"
 
-  trigger_counter=-1 # -1: already triggerd, 0: triggered, >0: count to trigger
   while exist_process "$game_pid"; do
+    sleep 0.1
+
     trigger_counter=$((trigger_counter >= 0 ? trigger_counter - 1 : trigger_counter))
     # $debug echo "trigger_counter: $trigger_counter"
 
@@ -2253,8 +2255,6 @@ lockdown_timer() {
       # $debug echo "send_cmd: LOCKDOWN"
       send_cmd "$LOCKDOWN"
     }
-
-    sleep 0.1
 
     # The following code will cause an error ("Illegal instruction: 4") on macOS(bash 3.2.57).
     #   sleep 0.1 & # wait in background for receiving the signal

--- a/tetris
+++ b/tetris
@@ -1642,8 +1642,6 @@ lockdown() {
 
   test_lockout && { # a whole Tetrimino Locks Down above the Skyline - Game Over
     # now lets sub process continue...
-    wakeup_ticker
-    wakeup_lockdown_timer
     gameover; return # ... Quit
   }
 
@@ -1655,7 +1653,6 @@ lockdown() {
 
   # now lets sub process continue...
   wakeup_ticker
-  wakeup_lockdown_timer
 }
 
 pause() {
@@ -1671,12 +1668,12 @@ pause() {
     show_hold
     pause=false
     wakeup_ticker
-    wakeup_lockdown_timer
+    $lock_phase && wakeup_lockdown_timer
     return
   fi
 
   stop_ticker
-  stop_lockdown_timer
+  $lock_phase && stop_lockdown_timer
   draw_pause
   clear_next
   clear_hold
@@ -2168,7 +2165,6 @@ init() {
   ready
 
   wakeup_ticker
-  wakeup_lockdown_timer
   capture_input
 
   get_next


### PR DESCRIPTION
It seems that the lockdown timer was shortened by 0.1ms in the regression of #72. Sorry.

Also guessing from the #82, it looks like you have made lockdown timer stop when it is not needed. However, it was keep running and I fixed it.